### PR TITLE
Python modules as individual resources

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,3 +7,4 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '1.1.0'
 
 depends 'git'
+depends 'python'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,7 @@
 #
 
 include_recipe "git"
-
+include_recipe "python"
 
 #### going to populate the table setup from the databag
 begin
@@ -39,11 +39,31 @@ rescue
     aws_creds['aws_secret_access_key_id'] = node['dynamic-dynamodb']['config']['global']['aws_secret_access_key_id']
 end
 
+#Create directory at compile time for git resource below
 directory "#{node['dynamic-dynamodb']['base_path']}/dynamic-dynamodb" do
     owner node['dynamic-dynamodb']['user']
     group node['dynamic-dynamodb']['group']
     mode 00755
-    action :create
+    action :nothing
+end.run_action(:create)
+
+# Sync git repo at compile time so we can create necessary package resources for required Python modules
+git "#{node['dynamic-dynamodb']['base_path']}/dynamic-dynamodb" do
+    repository "git://github.com/sebdah/dynamic-dynamodb.git"
+    reference "master"
+    user node['dynamic-dynamodb']['user']
+    group node['dynamic-dynamodb']['group']
+    action :nothing
+end.run_action(:sync)
+
+#Install required Python modules
+mods = File.new("#{node['dynamic-dynamodb']['base_path']}/dynamic-dynamodb/requirements.txt").read.split("\n").map! { |mod| { mod.split(/[!=<>]+/)[0] => mod.split(/[!=<>]+/)[1] } }
+modules = Hash.new
+mods.each {|mod| modules.merge!(mod)}
+modules.each do |k, v|
+  python_pip k do
+    version v
+  end
 end
 
 directory "#{node['dynamic-dynamodb']['log_path']}/dynamic-dynamodb" do
@@ -51,24 +71,6 @@ directory "#{node['dynamic-dynamodb']['log_path']}/dynamic-dynamodb" do
     group node['dynamic-dynamodb']['group']
     mode 00755
     action :create
-end
-
-
-git "#{node['dynamic-dynamodb']['base_path']}/dynamic-dynamodb" do
-    repository "git://github.com/sebdah/dynamic-dynamodb.git"
-    reference "master"
-    user node['dynamic-dynamodb']['user']
-    group node['dynamic-dynamodb']['group']
-    action :sync
-end
-
-script "Install Requirements" do
-  interpreter "bash"
-  user 'root'
-  group 'root'
-  code <<-EOH
-  /usr/local/bin/pip install -r "#{node['dynamic-dynamodb']['base_path']}/dynamic-dynamodb/requirements.txt"
-  EOH
 end
 
 template "#{node['dynamic-dynamodb']['base_path']}/dynamic-dynamodb/dynamic-dynamodb.conf" do


### PR DESCRIPTION
This patch replaces the script using pip to install needed python modules with the python_pip LWRP.  The directory and git resource that are run at compile time are so we have the requirements.txt file to parse and create pip resources for.  I also rearranged the order for readability putting together things done at compile time (the git and directory resources as well as the data gathering and requirements.txt parsing) followed by resources that are converged normally.
