### PR TITLE
Table definitions in attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,7 +9,13 @@ default['dynamic-dynamodb']['daemon'] = false
 default['dynamic-dynamodb']['config_file'] = 'dynamic-dynamodb.conf'
 default['dynamic-dynamodb']['config']['global']['aws_access_key_id'] = nil
 default['dynamic-dynamodb']['config']['global']['aws_secret_access_key_id'] = nil
+default['dynamic-dynamodb']['config']['global']['creds_data_bag'] = 'aws'
+default['dynamic-dynamodb']['config']['global']['creds_data_bag_item'] = 'dynamic-dynamodb'
 default['dynamic-dynamodb']['config']['global']['region'] = 'us-east-1'
 default['dynamic-dynamodb']['config']['global']['check_interval'] = 30
 default['dynamic-dynamodb']['config']['global']['circuit_breaker_url'] = nil
 default['dynamic-dynamodb']['config']['global']['circuit_breaker_timeout'] = 30
+default['dynamic-dynamodb']['config']['tables'] = nil # Define a hash of values for all tables instead of querying a data_bag
+                                            # -OR- define an array of table names to filter the data_bay query
+default['dynamic-dynamodb']['config']['tables_data_bag'] = 'dynamic-dynamodb'
+default['dynamic-dynamodb']['config']['tables_data_bag_item'] = 'tables'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,3 +13,5 @@ default['dynamic-dynamodb']['config']['global']['region'] = 'us-east-1'
 default['dynamic-dynamodb']['config']['global']['check_interval'] = 30
 default['dynamic-dynamodb']['config']['global']['circuit_breaker_url'] = nil
 default['dynamic-dynamodb']['config']['global']['circuit_breaker_timeout'] = 30
+default['dynamic-dynamodb']['tables'] = nil # Define a hash of values for all tables instead of querying a data_bag
+                                            # -OR- define an array of table names to filter the data_bay query

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,7 +22,7 @@ include_recipe "git"
 
 
 #### going to populate the table setup from attributes or databag
-if node['dynamic-dynamodb']['config']['tables'].class == Hash
+if [ Chef::Node::ImmutableMash , Mash ].include? node['dynamic-dynamodb']['config']['tables'].class
   tables_data = node['dynamic-dynamodb']['config']['tables']
 else
   begin


### PR DESCRIPTION
This commit adds flexibility to table definitions by:
- allows table definitions to be defined entirely in attributes using a hash in the node['dynamic-dynamodb']['config']['tables'] attribute.
  - allows filtering the defined tables from the data bag using an array of table names in the node['dynamic-dynamodb']['config']['tables'] attribute.
  - allows specifying the data_bag and data_bag_item names for both table definitions and aws credentials

The default behavior should not be changed as the attribute defaults are set to the same values as before.
